### PR TITLE
Add giantswarm.io/managed-by label so apps are accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `giantswarm.io/managed-by` label so apps are accepted by `app-admission-controller`.
+- Remove `app-operator.giantswarm.io/version` label as its replaced by `giantswarm.io/cluster`.
+
 ## [0.1.2] - 2022-03-09
 
 ## [0.1.1] - 2022-03-09

--- a/helm/default-apps-aws/templates/_helpers.tpl
+++ b/helm/default-apps-aws/templates/_helpers.tpl
@@ -17,7 +17,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "labels.common" -}}
-app-operator.giantswarm.io/version: 5.5.1
 app.kubernetes.io/name: {{ include "name" . }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
@@ -26,6 +25,7 @@ app.kubernetes.io/managed-by: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/cluster: {{ .Values.clusterName | quote }}
+giantswarm.io/managed-by: {{ .Release.Name | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 giantswarm.io/service-type: managed
 {{- end -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21038

This PR:

- Adds the managed by label to the child apps with the name of the parent app.
e.g. `giantswarm.io/managed-by: ross2-default-apps`

This means that app-admission-controller will accept them straightaway and there is no confusing failed status until the kubeconfig exists.

- Removes the `app-operator.giantswarm.io/version` label as its replaced by `giantswarm.io/cluster`.

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
