### PR TITLE
Explicitly define apps configmaps so we can use helm values on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `aws-pod-identity-webhook` for IRSA support.
 
+### Changed
+
+- Explicitly define Apps configmaps so we can use helm values when defining the config map content.
+
 ## [0.5.5] - 2022-10-04
 
 ## [0.5.4] - 2022-09-14

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -22,60 +22,42 @@ spec:
     secret:
       name: {{ $.Values.clusterName }}-kubeconfig
       namespace: {{ $.Release.Namespace}}
-  {{- with .clusterValues }}
-  {{- if or .configMap .secret }}
   config:
-  {{- if .configMap }}
     configMap:
       name: {{ $.Values.clusterName }}-cluster-values
       namespace: {{ $.Release.Namespace }}
-  {{- end }}
-  {{- if .secret }}
-    secret:
-      name: {{ $.Values.clusterName }}-cluster-values
-      namespace: {{ $.Release.Namespace }}
-  {{- end }}
-  {{- end }} 
-{{- end }}
-{{- with (get $.Values.userConfig $key) }}
+  {{- with (get $.Values.userConfig $key) }}
   userConfig:
-  {{- if .configMap }}
     configMap:
       name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
       namespace: {{ $.Release.Namespace }}
   {{- end }}
-  {{- if .secret }}
-    secret:
-      name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
-      namespace: {{ $.Release.Namespace }}
-  {{- end }}
-  {{- end }}
+{{- end }}
 
-{{- with (get $.Values.userConfig $key) }}
-{{- if .configMap }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
+  name: {{ $.Values.clusterName }}-cilium-user-values
   namespace: {{ $.Release.Namespace }}
 data:
-  {{- (tpl (.configMap | toYaml | toString) $) | nindent 2 }}
-{{- end }}
-{{- if .secret }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    {{- include "labels.common" $ | nindent 4 }}
-  name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
-  namespace: {{ $.Release.Namespace }}
-stringData:
-  {{- (tpl (.secret | toYaml | toString) $) | nindent 2 }}
-{{- end }}
-{{- end }}
-
-{{- end }}
+  values: |
+    ipam:
+      mode: kubernetes
+    k8sServiceHost: api.{{ $.Values.baseDomain }}
+    k8sServicePort: 443
+    kubeProxyReplacement: strict
+    hubble:
+      relay:
+        enabled: true
+    defaultPolicies:
+      enabled: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -17,17 +17,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -50,17 +39,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -85,17 +63,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -118,17 +85,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -153,17 +109,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -186,17 +131,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -221,17 +155,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -254,17 +177,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -289,17 +201,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -322,17 +223,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -357,17 +247,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -390,17 +269,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -425,17 +293,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -458,17 +315,6 @@
                         },
                         "chartName": {
                             "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -493,17 +339,6 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -527,17 +362,7 @@
             "type": "object",
             "properties": {
                 "cilium": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "boolean"
                 }
             }
         }

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -1,30 +1,15 @@
 clusterName: ""
 organization: ""
 
+# Add to this map the Apps that have a 'user-values' configmap defined in apps.yaml.
 userConfig:
-  cilium:
-    configMap:
-      values: |
-        ipam:
-          mode: kubernetes
-        defaultPolicies:
-          enabled: true
-          tolerations:
-            - effect: NoSchedule
-              operator: Exists
-            - effect: NoExecute
-              operator: Exists
-            - key: CriticalAddonsOnly
-              operator: Exists
+  cilium: true
 
 apps:
   aws-ebs-csi-driver:
     appName: aws-ebs-csi-driver
     chartName: aws-ebs-csi-driver-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -34,9 +19,6 @@ apps:
     appName: aws-pod-identity-webhook
     chartName: aws-pod-identity-webhook
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -46,9 +28,6 @@ apps:
     appName: capi-node-labeler
     chartName: capi-node-labeler
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -58,9 +37,6 @@ apps:
     appName: cert-exporter
     chartName: cert-exporter
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -70,9 +46,6 @@ apps:
     appName: cert-manager
     chartName: cert-manager-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -82,9 +55,6 @@ apps:
     appName: coredns
     chartName: coredns-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -94,9 +64,6 @@ apps:
     appName: cilium
     chartName: cilium
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -106,9 +73,6 @@ apps:
     appName: external-dns
     chartName: external-dns-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -118,9 +82,6 @@ apps:
     appName: kiam
     chartName: kiam-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -130,9 +91,6 @@ apps:
     appName: kube-state-metrics
     chartName: kube-state-metrics
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -142,9 +100,6 @@ apps:
     appName: metrics-server
     chartName: metrics-server-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -154,9 +109,6 @@ apps:
     appName: net-exporter
     chartName: net-exporter
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -166,9 +118,6 @@ apps:
     appName: node-exporter
     chartName: node-exporter-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -178,9 +127,6 @@ apps:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -190,9 +136,6 @@ apps:
     appName: vertical-pod-autoscaler-crd
     chartName: vertical-pod-autoscaler-crd
     catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Explicitly define apps configmaps so we can use helm values on them. That way we can use dynamic values passed when installing the app in the configmaps.

### Checklist

- [X] Update changelog in `CHANGELOG.md`.
- [X] Make sure `values.yaml` is valid.
