### PR TITLE
Bump Cilium to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped Cilium to 0.4.1
+- Bumped Cilium to 0.4.2
 
 ## [0.5.5] - 2022-10-04
 

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -101,7 +101,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cilium-app
-    version: 0.4.1
+    version: 0.4.2
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

- Bumps cilium to 0.4.2

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
