### PR TITLE
Remove kiam from default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `kiam-app` from the apps.
+
 ## [0.22.0] - 2023-03-22
 
 ### Changed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -127,18 +127,6 @@ apps:
     # used by renovate
     # repo: giantswarm/external-dns-app
     version: 2.33.0
-  kiam:
-    appName: kiam
-    chartName: kiam-app
-    catalog: default
-    clusterValues:
-      configMap: true
-      secret: true
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/kiam-app
-    version: 2.6.0
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics


### PR DESCRIPTION
### What this PR does / why we need it

Now we use `irsa`.  Do we still need to deploy `kiam`? I guess not.

Towards - https://github.com/giantswarm/roadmap/issues/1781

### Checklist

- [X] Update changelog in CHANGELOG.md.
