### PR TITLE
Update: Bump external-dns to v2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped external-dns to v2.19.0.
+
 ## [0.9.0] - 2022-11-18
 
 ### Changed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -119,7 +119,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/external-dns-app
-    version: 2.18.0
+    version: 2.19.0
   kiam:
     appName: kiam
     chartName: kiam-app


### PR DESCRIPTION
The PR does the following:
- Bumps `external-dns` to `v2.19.0`



### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
