### PR TITLE
Re-enable observability-bundle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Re-enable observability-bundle.
+
 ## [0.10.0] - 2022-11-18
 
 ### Changed

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -447,6 +447,40 @@
                         }
                     }
                 },
+                "observability-bundle": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "inCluster": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "vpa": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -204,3 +204,15 @@ apps:
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-crd
     version: 1.0.1
+  observability-bundle:
+    appName: observability-bundle
+    chartName: observability-bundle
+    catalog: default
+    namespace: ""
+    inCluster: true
+    clusterValues:
+      configMap: true
+      secret: false
+    # used by renovate
+    # repo: giantswarm/observability-bundle
+    version: 0.1.2

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -215,4 +215,4 @@ apps:
       secret: false
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.1.2
+    version: 0.1.3


### PR DESCRIPTION
Re-enable observability-bundle. #108

The app-admission fix has been released: 

- https://github.com/giantswarm/app/pull/266
- https://github.com/giantswarm/app-admission-controller/releases/tag/v0.18.2

we just need the cluster-apps-operator to be released first: https://github.com/giantswarm/cluster-apps-operator/pull/308