### PR TITLE
Configure ebs csi driver for proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configured ebs csi driver for proxy.
+
 ## [0.11.0] - 2022-11-25
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -30,7 +30,7 @@ apps:
     catalog: default
     clusterValues:
       configMap: true
-      secret: false
+      secret: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -35,7 +35,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/aws-ebs-csi-driver-app
-    version: 2.18.0
+    version: 2.19.0
   aws-pod-identity-webhook:
     appName: aws-pod-identity-webhook
     chartName: aws-pod-identity-webhook


### PR DESCRIPTION
### What this PR does / why we need it

We need the EBS csi driver to get the cluster values secret, because we need it on private clusters where the driver needs to go through a proxy.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
