### PR TITLE
configure net-exporter to use aws ntp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `net-expoter` to use AWS NTP sever.
+
 ## [0.12.4] - 2022-12-19
 
 ### Changed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -22,6 +22,11 @@ userConfig:
               operator: Exists
             - key: CriticalAddonsOnly
               operator: Exists
+  netExporter:
+    configMap:
+      values: |
+        NetExporter:
+          NTPServers: 169.254.169.123
 
 apps:
   aws-ebs-csi-driver:


### PR DESCRIPTION
### What this PR does / why we need it

For private clusters without internet access, it is not possible to use default ntp server. This PR replaces default ntp server with AWS NTP server which is available on local networks.

* giantswarm/roadmap#1800

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
