### PR TITLE
Bump node-exporter-app to v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `net-expoter` to use AWS NTP sever.
+- Bump node-exporter-app to v1.14.1
 
 ## [0.12.4] - 2022-12-19
 


### PR DESCRIPTION
Dependency was updated by renovate in PR https://github.com/giantswarm/default-apps-aws/pull/134

### What this PR does / why we need it

Towards roadmap - https://github.com/giantswarm/roadmap/issues/1811

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
