### PR TITLE
Update: dependency aws-pod-identity-webhook to v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `aws-pod-identity-webhook` to `v1.5.0`
+
 ## [0.16.0] - 2023-01-24
 
 ### Changed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -57,7 +57,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/aws-pod-identity-webhook
-    version: 1.4.0
+    version: 1.5.0
   capi-node-labeler:
     appName: capi-node-labeler
     chartName: capi-node-labeler


### PR DESCRIPTION
### What this PR does / why we need it
Bumps dependency `aws-pod-identity-webhook` to `v1.5.0`

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
