### PR TITLE
Add promtail enabling/disabling to observability-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `promtail` enabling/disabling to `observability-bundle`
+
 ## [0.19.1] - 2023-02-17
 
 ### Changed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -32,6 +32,12 @@ userConfig:
       values: |
         NetExporter:
           NTPServers: 169.254.169.123
+  observabilityBundle:
+    configMap:
+      values: |
+        apps:
+          promtail-app:
+            enabled: false
 
 apps:
   aws-ebs-csi-driver:
@@ -221,7 +227,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
-    forceUpgrade: false
+    forceUpgrade: true
     inCluster: true
     namespace: kube-system
     # used by renovate

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -227,7 +227,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
-    forceUpgrade: true
+    forceUpgrade: false
     inCluster: true
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2054

In order to enable/disable `promtail-app` on `capa` cluster.
This app is embedded in the `observability-bundle`.

### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description 
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
