### PR TITLE
Make cert-manager use only recursive nameservers since authoritative ones cannot be reached directly from private cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make cert-manager use only recursive nameservers for DNS01 solver. The public, authoritative ones cannot be reached directly from private clusters.
+
 ## [0.23.2] - 2023-03-24
 
 ### Fixed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -2,6 +2,21 @@ clusterName: ""
 organization: ""
 
 userConfig:
+  certManager:
+    controller:
+      extraArgs:
+        # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
+        # their public IPs. Since those are not reachable from private clusters, we instead rely on the
+        # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
+        #
+        # Without this, we get an error like
+        #
+        #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
+        #
+        # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
+        #
+        # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
+        - --dns01-recursive-nameservers-only
   externalDns:
     configMap:
       values: |


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2200, replaces the invalid PR https://github.com/giantswarm/config/pull/1660

### What this PR does / why we need it

cert-manager goes through the NS record of the zone and directly contacts the listed nameservers. That doesn't work on private clusters, since they cannot reach the public Internet directly. Instead, use the recursive nameservers, i.e. a regular DNS lookup with `/etc/resolv.conf` settings.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
