### PR TITLE
Fix cert-manager config not being used by mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `observability-bundle` to 0.4.0
 
+### Fixed
+
+- Fix cert-manager config not being used by mistake (`--dns01-recursive-nameservers-only` argument which is relevant in private clusters)
+
 ### Removed
 
 - Remove kube-state-metrics app as it is now included in the observability-bundle.

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -529,6 +529,19 @@
         "userConfig": {
             "type": "object",
             "properties": {
+                "certManager": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "cilium": {
                     "type": "object",
                     "properties": {
@@ -543,6 +556,19 @@
                     }
                 },
                 "externalDns": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "netExporter": {
                     "type": "object",
                     "properties": {
                         "configMap": {

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -3,20 +3,22 @@ organization: ""
 
 userConfig:
   certManager:
-    controller:
-      extraArgs:
-        # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
-        # their public IPs. Since those are not reachable from private clusters, we instead rely on the
-        # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
-        #
-        # Without this, we get an error like
-        #
-        #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
-        #
-        # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
-        #
-        # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
-        - --dns01-recursive-nameservers-only
+    configMap:
+      values: |
+        controller:
+          extraArgs:
+            # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
+            # their public IPs. Since those are not reachable from private clusters, we instead rely on the
+            # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
+            #
+            # Without this, we get an error like
+            #
+            #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
+            #
+            # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
+            #
+            # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
+            - --dns01-recursive-nameservers-only
   externalDns:
     configMap:
       values: |


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2200

Fix for #196. The JSON Schema could have saved me from the mistake, so I adjusted it accordingly.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
