### PR TITLE
Add cluster-values secret to cloud-controller so it gets proxy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix catalog for `aws-ebs-csi-driver`.
 
+### Changed
+
+- Add the `cluster-values` secret to the `aws-cloud-controller-manager` app, so it gets the proxy configuration. 
+
 ## [0.27.0] - 2023-04-26
 
 ### Fixed

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -54,12 +54,12 @@ apps:
     catalog: default
     clusterValues:
       configMap: true
-      secret: false
+      secret: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/aws-cloud-controller-manager-app
-    version: v1.24.1-gs1
+    version: v1.24.1-gs3
   aws-ebs-csi-driver:
     appName: aws-ebs-csi-driver
     chartName: aws-ebs-csi-driver-app


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/roadmap/issues/2426

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Won't work yet. It requires a version of `aws-cloud-controller-manager` that includes [this change](https://github.com/giantswarm/aws-cloud-controller-manager-app/pull/21).
