### PR TITLE
etcd-kubernetes-resources-count-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `etcd-kubernetes-resources-count-exporter`.
+
 ## [0.29.0] - 2023-05-10
 
 ### Changed

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -5,6 +5,40 @@
         "apps": {
             "type": "object",
             "properties": {
+                "aws-cloud-controller-manager": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "aws-ebs-csi-driver": {
                     "type": "object",
                     "properties": {
@@ -243,7 +277,7 @@
                         }
                     }
                 },
-                "externalDns": {
+                "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -277,7 +311,7 @@
                         }
                     }
                 },
-                "kiam": {
+                "externalDns": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -473,6 +507,9 @@
                                 }
                             }
                         },
+                        "dependsOn": {
+                            "type": "string"
+                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -543,6 +580,19 @@
                     }
                 },
                 "cilium": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {
                         "configMap": {

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -46,6 +46,14 @@ userConfig:
       values: |
         NetExporter:
           NTPServers: 169.254.169.123
+  etcdKubernetesResourceCountExporter:
+    configMap:
+      values: |
+        etcd:
+          hostPath: "/etc/kubernetes/pki/etcd/"
+          cacertpath: "/certs/ca.crt"
+          certpath: "/certs/server.crt"
+          keypath: "/certs/server.key"
 
 apps:
   aws-cloud-controller-manager:
@@ -230,3 +238,15 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 0.7.0
+  etcdKubernetesResourceCountExporter:
+    appName: etcd-kubernetes-resources-count-exporter
+    chartName: etcd-kubernetes-resources-count-exporter
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/etcd-kubernetes-resources-count-exporter
+    version: 1.3.0


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/25482

### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites