### PR TITLE
set extenal-dns config using explicit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change the etcd prefix for `etcd-kubernetes-resources-count-exporter`.
 - Update `cert-manager-app` values in preparation of v3.0.0 release.
+- Set `extenal-dns` configuration using explicit values.
 
 ## [0.30.0] - 2023-06-28
 

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -36,8 +36,22 @@ userConfig:
   externalDns:
     configMap:
       values: |
+        provider: aws
         aws:
           irsa: "true"
+          batchChangeInterval: null
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: {{ .Values.clusterName }}-Route53Manager-Role
+        domainFilters:
+          - {{ .Values.baseDomain }}
+        txtOwnerId: giantswarm-io-external-dns
+        txtPrefix: {{ .Values.clusterName }}
+        annoationFilter: giantswarm.io/external-dns=managed
+        sources:
+          - service
+        extraArgs:
+          - "--aws-batch-change-interval=10s"
   netExporter:
     configMap:
       values: |

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -47,7 +47,7 @@ userConfig:
           - {{ .Values.baseDomain }}
         txtOwnerId: giantswarm-io-external-dns
         txtPrefix: {{ .Values.clusterName }}
-        annoationFilter: giantswarm.io/external-dns=managed
+        annotationFilter: giantswarm.io/external-dns=managed
         sources:
           - service
         extraArgs:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

This is needed in preparation for external-dns app v3, where the
provider specific logic has been moved to configuration using values.

Towards https://github.com/giantswarm/giantswarm/issues/27508

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
