### PR TITLE
Update cert-manager-app values for upcoming major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change the etcd prefix for `etcd-kubernetes-resources-count-exporter`.
+- Update `cert-manager-app` values in preparation of v3.0.0 release.
 
 ## [0.30.0] - 2023-06-28
 

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -5,6 +5,7 @@ userConfig:
   certManager:
     configMap:
       values: |
+        # cert-manager-app v2.x.x
         controller:
           extraArgs:
             # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
@@ -19,6 +20,19 @@ userConfig:
             #
             # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
             - --dns01-recursive-nameservers-only
+        # cert-manager-app v3.x.x
+        # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
+        # their public IPs. Since those are not reachable from private clusters, we instead rely on the
+        # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
+        #
+        # Without this, we get an error like
+        #
+        #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
+        #
+        # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
+        #
+        # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
+        dns01RecursiveNameserversOnly: true
   externalDns:
     configMap:
       values: |


### PR DESCRIPTION
### What this PR does / why we need it

Upcoming cert-manager-app major contains a breaking change in the values. This PR updates the default-app values to work on both v2.x.x and v3.x.x

Towards https://github.com/giantswarm/giantswarm/issues/27604

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
