### PR TITLE
add-enabled-value-to-each-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `enabled` property to each app, whitch controls, if the app is deployed or not.
+
 ### Changed
 
 - Change the etcd prefix for `etcd-kubernetes-resources-count-exporter`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `enabled` property to each app, whitch controls, if the app is deployed or not.
+- Add `enabled` property to each app, which controls, if the app is deployed or not.
 
 ### Changed
 

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $value := .Values.apps }}
 {{- $appName := .appName }}
+{{- if .enabled }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
@@ -90,5 +91,5 @@ stringData:
   {{- (tpl (.secret | toYaml | toString) $) | nindent 2 }}
 {{- end }}
 {{- end }}
-
+{{- end }}
 {{- end }}

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -92,4 +92,5 @@ stringData:
 {{- end }}
 {{- end }}
 {{- end }}
+
 {{- end }}

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -77,6 +77,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -89,6 +90,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -101,6 +103,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -110,6 +113,7 @@ apps:
     appName: cert-manager
     chartName: cert-manager-app
     catalog: default
+    enabled: true
     clusterValues:
       configMap: true
       secret: true
@@ -125,6 +129,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -137,6 +142,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -149,6 +155,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -161,6 +168,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -174,6 +182,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -186,6 +195,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
@@ -199,6 +209,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2609

this allows disabling certain apps for EKS

```
apiVersion: v1
data:
  values: |
    clusterName: vac0eks
    organization: giantswarm
    apps:
      aws-pod-identity-webhook:
        enabled: false
      etcdKubernetesResourceCountExporter:
        enabled: false
```