### PR TITLE
Add dependency from `aws-pod-identity-webhook` on `cert-manager` because otherwise the chart may be deployed without the required `Certificate` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add dependency from `aws-pod-identity-webhook` on `cert-manager` because otherwise the chart may be deployed without the required `Certificate` object
+
 ## [0.31.0] - 2023-08-07
 
 ### Added
@@ -52,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add the `cluster-values` secret to the `aws-cloud-controller-manager` app, so it gets the proxy configuration. 
+- Add the `cluster-values` secret to the `aws-cloud-controller-manager` app, so it gets the proxy configuration.
 
 ## [0.27.0] - 2023-04-26
 

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -77,7 +77,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
-    dependsOn: cert-manager # since aws-pod-identity-webhook installs a `Certificate` object
+    dependsOn: cert-manager  # since aws-pod-identity-webhook installs a `Certificate` object
     enabled: true
     forceUpgrade: true
     namespace: kube-system

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -77,6 +77,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: cert-manager # since aws-pod-identity-webhook installs a `Certificate` object
     enabled: true
     forceUpgrade: true
     namespace: kube-system


### PR DESCRIPTION
### What this PR does / why we need it

cluster-test-suite tests were intermittently failing. I observed one case where `aws-pod-identity-webhook-app` was installed before `cert-manager`, and even though chart-operator's Helm installation failed once because the cert-manager `Certificate` CRD wasn't installed yet, it succeeded a bit later with `deployed` state while the important `Certificate` object within `aws-pod-identity-webhook-app` was _still_ not deployed. That is really weird since the app contains that object unconditionally, and Helm should not have succeeded at all. With `dependsOn`, this can hopefully be avoided and might even be faster to get the cluster ready, as pod startup retries are avoided until more requirements are met.

[Chat ref](https://gigantic.slack.com/archives/C02HLSDH3DZ/p1691657079284819)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
/run cluster-test-suites
