### PR TITLE
do not force cert-manager upgrade

### DIFF
--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -118,7 +118,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
-    forceUpgrade: true
+    forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app


### PR DESCRIPTION
### What this PR does / why we need it

This PR removes the force upgrade annotation from cert-manager-app. Related Issue giantswarm/giantswarm#27963

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
