### PR TITLE
Remove old pipelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,16 +8,10 @@
 ### Trigger e2e tests
 
 <!--
-We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
-- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
-- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.
+We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
+- `/run cluster-test-suites`
 
-After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
-It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).
-
-If for some reason you want to skip the e2e tests, remove the following lines.
+If for some reason you want to skip the e2e tests, remove the following line.
 -->
 
-/test create
-/test upgrade
 /run cluster-test-suites


### PR DESCRIPTION
### What this PR does / why we need it

We now run both creation and update tests using the same pipeline.
