### PR TITLE
Enable cilium network policies for cert manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Don't use `--force` when installing/upgrading apps.
+- Enable cilium NetworkPolicies for `cert-manager-app`.
+- Update `cert-manager-app` to `v3.2.0`.
 
 ## [0.32.0] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't use `--force` when installing/upgrading apps.
+
 ## [0.32.0] - 2023-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't use `--force` when installing/upgrading apps.
 - Enable cilium NetworkPolicies for `cert-manager-app`.
-- Update `cert-manager-app` to `v3.2.0`.
 
 ## [0.32.0] - 2023-08-10
 

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -6,7 +6,6 @@ apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   annotations:
-    chart-operator.giantswarm.io/force-helm-upgrade: "{{ .forceUpgrade }}"
     {{- if .dependsOn }}
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -28,9 +28,6 @@
                                 }
                             }
                         },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -61,9 +58,6 @@
                                     "type": "boolean"
                                 }
                             }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -96,9 +90,6 @@
                                 }
                             }
                         },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -129,9 +120,6 @@
                                     "type": "boolean"
                                 }
                             }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -164,9 +152,6 @@
                                 }
                             }
                         },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -197,9 +182,6 @@
                                     "type": "boolean"
                                 }
                             }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -232,9 +214,6 @@
                                 }
                             }
                         },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -265,9 +244,6 @@
                                     "type": "boolean"
                                 }
                             }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -300,9 +276,6 @@
                                 }
                             }
                         },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -333,9 +306,6 @@
                                     "type": "boolean"
                                 }
                             }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "inCluster": {
                             "type": "boolean"
@@ -373,9 +343,6 @@
                         },
                         "dependsOn": {
                             "type": "string"
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -79,7 +79,6 @@ apps:
       secret: false
     dependsOn: cert-manager  # since aws-pod-identity-webhook installs a `Certificate` object
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/aws-pod-identity-webhook
@@ -92,7 +91,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/capi-node-labeler-app
@@ -105,7 +103,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-exporter
@@ -118,7 +115,6 @@ apps:
     clusterValues:
       configMap: true
       secret: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app
@@ -131,7 +127,6 @@ apps:
       configMap: true
       secret: true
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/external-dns-app
@@ -144,7 +139,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/metrics-server-app
@@ -157,7 +151,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/net-exporter
@@ -170,7 +163,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/node-exporter-app
@@ -184,7 +176,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-app
@@ -197,7 +188,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: false
     inCluster: true
     namespace: kube-system
     # used by renovate
@@ -211,7 +201,6 @@ apps:
       configMap: true
       secret: false
     enabled: true
-    forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/etcd-kubernetes-resources-count-exporter

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -34,7 +34,7 @@ userConfig:
         # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
         dns01RecursiveNameserversOnly: true
         ciliumNetworkPolicy:
-          enabled: false
+          enabled: true
   externalDns:
     configMap:
       values: |
@@ -120,7 +120,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app
-    version: 3.1.0
+    version: 3.2.0
   externalDns:
     appName: external-dns
     chartName: external-dns-app

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -33,6 +33,8 @@ userConfig:
         #
         # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
         dns01RecursiveNameserversOnly: true
+        ciliumNetworkPolicy:
+          enabled: false
   externalDns:
     configMap:
       values: |

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -120,7 +120,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app
-    version: 3.2.0
+    version: 3.1.0
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
### What this PR does / why we need it

This PR builds on #302 and enables cilium NetworkPolicies for cert-manager-app. It also upgrades cert-manager-app to 3.2.0

Related: giantswarm/giantswarm#27963

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
