### PR TITLE
Add pre-install job to depend on cilium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add helm pre-install job that waits for `cilium` `HelmRelease` to be `Ready` so that default apps are only deployed after `cilium` is deployed.
+
 ## [0.33.0] - 2023-08-28
 
 ### Changed

--- a/helm/default-apps-aws/templates/pre-install/job.yaml
+++ b/helm/default-apps-aws/templates/pre-install/job.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: default-apps-wait-for-cni
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: default-apps-wait-for-cni
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: wait-crds
+          image: "quay.io/giantswarm/docker-kubectl:1.24.4"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+            limits:
+              cpu: 200m
+              memory: 100Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsNonRoot: true
+          command:
+            - sh
+          args:
+            - -c
+            - |
+              kubectl wait --for=condition=Ready -n {{ .Release.Namespace }} helmrelease/{{ .Values.clusterName }}-cilium

--- a/helm/default-apps-aws/templates/pre-install/psp.yaml
+++ b/helm/default-apps-aws/templates/pre-install/psp.yaml
@@ -1,0 +1,64 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: default-apps-wait-for-cni
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'projected'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-apps-wait-for-cni-psp
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - default-apps-wait-for-cni
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-apps-wait-for-cni
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: default-apps-wait-for-cni-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: default-apps-wait-for-cni
+    namespace: {{ .Release.Namespace }}

--- a/helm/default-apps-aws/templates/pre-install/rbac.yaml
+++ b/helm/default-apps-aws/templates/pre-install/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-apps-wait-for-cni
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-apps-wait-for-cni
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-apps-wait-for-cni
+subjects:
+  - kind: ServiceAccount
+    name: default-apps-wait-for-cni
+    namespace: {{ .Release.Namespace }}

--- a/helm/default-apps-aws/templates/pre-install/serviceaccount.yaml
+++ b/helm/default-apps-aws/templates/pre-install/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-apps-wait-for-cni
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded


### PR DESCRIPTION
### What this PR does / why we need it

Some times we witness some weirdness going on when creating new clusters due to the fact that default apps fail to get installed while cilium is not deployed in the cluster. In this PR I'm adding a pre-install job that checks for cilium `HelmRelease` to be ready before deploying the default apps, to make that dependency explicit.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
