### PR TITLE
Drop usage of clusterID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop usage of `clusterID` in favour of `clusterName`.
+
 ## [0.33.0] - 2023-08-28
 
 ### Changed

--- a/helm/default-apps-aws/ci/ci-values.yaml
+++ b/helm/default-apps-aws/ci/ci-values.yaml
@@ -1,1 +1,1 @@
-clusterID: test
+clusterName: test

--- a/helm/default-apps-aws/ci/test-values.yaml
+++ b/helm/default-apps-aws/ci/test-values.yaml
@@ -1,1 +1,1 @@
-clusterID: test
+clusterName: test

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- if .dependsOn }}
     # app-operator will make sure that the app on which it depends is installed before
-    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}


### PR DESCRIPTION
### What this PR does / why we need it
Apparently we don't need `clusterID` anymore.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
