### PR TITLE
Add dependency between cert-manager and prom crds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped `cert-manager-app` to `v3.4.0`
+- Bumped `cert-manager-app` to `v3.4.0`.
+- Add dependency from `cert-manager` on `prometheus-operator-crd` because it needs `ServiceMonitors`.
 
 ## [0.33.0] - 2023-08-28
 

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -117,6 +117,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    dependsOn: prometheus-operator-crd
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app


### PR DESCRIPTION
### What this PR does / why we need it
[After `cert-manager` release `v3.4.0`](https://github.com/giantswarm/cert-manager-app/blob/main/CHANGELOG.md#changed), it needs `ServiceMonitor` CRD to be present.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
