### PR TITLE
Add chart-operator-extensions and regenerate Helm values.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
+
 ## [0.34.0] - 2023-09-28
 
 ### Changed

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -28,6 +28,12 @@
                                 }
                             }
                         },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -58,6 +64,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -90,6 +99,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -120,6 +132,49 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "chartOperatorExtensions": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -152,6 +207,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -182,6 +240,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -214,6 +275,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -244,6 +308,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"
@@ -276,6 +343,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },
@@ -306,6 +376,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "inCluster": {
                             "type": "boolean"
@@ -343,6 +416,9 @@
                         },
                         "dependsOn": {
                             "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "namespace": {
                             "type": "string"

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -128,8 +128,8 @@ apps:
     catalog: default
     enabled: true
     clusterValues:
-      configMap: true
-      secret: true
+      configMap: false
+      secret: false
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
     # used by renovate

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -132,6 +132,8 @@ apps:
       secret: true
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
+    # used by renovate
+    # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
   externalDns:
     appName: external-dns

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -122,6 +122,17 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 3.4.0
+  chartOperatorExtensions:
+    appName: chart-operator-extensions
+    chartName: chart-operator-extensions
+    catalog: default
+    enabled: true
+    clusterValues:
+      configMap: true
+      secret: true
+    dependsOn: prometheus-operator-crd
+    namespace: giantswarm
+    version: 1.1.1
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
### What this PR does / why we need it

Towards: https://github.com/giantswarm/giantswarm/issues/27558

Add `chart-operator-extensions` that contains service monitors for `chart-operator`. As of that, it depends on `prometheus-operator-crd`.

Also regenerated `values.schema.json` because of the updated `values.yaml` file.

This will fully take effect after bumping chart operator beyond: https://github.com/giantswarm/chart-operator/pull/1029 (Will be released as `chart-operator` version `v3.0.0` probably).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
