### PR TITLE
Add cluster-autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster-autoscaler`.
+
 ## [0.35.0] - 2023-11-02
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -140,7 +140,7 @@ apps:
     chartName: cluster-autoscaler-app
     catalog: default
     clusterValues:
-      configMap: true
+      configMap: false
       secret: false
     enabled: true
     namespace: kube-system

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -140,13 +140,13 @@ apps:
     chartName: cluster-autoscaler-app
     catalog: default
     clusterValues:
-      configMap: false
+      configMap: true
       secret: false
     enabled: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cluster-autoscaler-app
-    version: 1.27.3-gs1
+    version: 1.27.3-gs2
   externalDns:
     appName: external-dns
     chartName: external-dns-app

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -135,6 +135,18 @@ apps:
     # used by renovate
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
+  cluster-autoscaler:
+    appName: cluster-autoscaler
+    chartName: cluster-autoscaler-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    enabled: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/cluster-autoscaler-app
+    version: 1.27.3-gs1
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
### What this PR does / why we need it

This PR introduces the cluster-autoscaler with version 1.27.x because MachinePools are introduced with CA >= 1.27 only but it works with our current Kubernetes version.

I tried to make an overview how it works:
<img width="925" alt="image" src="https://github.com/giantswarm/roadmap/assets/1936982/1f42d708-1c8c-4144-8112-2b760e1537fc">

Issue: https://github.com/giantswarm/roadmap/issues/2927



### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites