### PR TITLE
Switch cluster-autoscaler to IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- IRSA for cluster-autoscaler.
+
 ## [0.36.0] - 2023-11-07
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -35,6 +35,12 @@ userConfig:
         dns01RecursiveNameserversOnly: true
         ciliumNetworkPolicy:
           enabled: true
+  cluster-autoscaler:
+    configMap:
+      values: |
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: {{ .Values.clusterName }}-cluster-autoscaler-role
   externalDns:
     configMap:
       values: |
@@ -146,7 +152,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cluster-autoscaler-app
-    version: 1.27.3-gs2
+    version: 1.27.3-gs3
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
### What this PR does / why we need it

This PR allows cluster-autscaler to assume a specific IAM role for AWS API calls instead of using the instance profile.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites