### PR TITLE
Use YAML object for app configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+Now we use a YAML object for the apps configuration instead of a string field.
+If you were passing custom values to the apps then you need to pass them as individual properties now.
+For example, this
+
+```yaml
+userConfig:
+  certManager:
+    configMap:
+      values: |
+        controller:
+          defaultIssuer:
+            name: private-giantswarm
+```
+
+Needs to be changed to this
+
+```yaml
+userConfig:
+  certManager:
+    configMap:
+      values:
+        controller:
+          defaultIssuer:
+            name: private-giantswarm
+```
+
+### Changed
+
+- Use a YAML object for the apps configuration.
+
 ## [0.40.0] - 2023-11-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,37 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking changes
-
-Now we use a YAML object for the apps configuration instead of a string field.
-If you were passing custom values to the apps then you need to pass them as individual properties now.
-For example, this
-
-```yaml
-userConfig:
-  certManager:
-    configMap:
-      values: |
-        controller:
-          defaultIssuer:
-            name: private-giantswarm
-```
-
-Needs to be changed to this
-
-```yaml
-userConfig:
-  certManager:
-    configMap:
-      values:
-        controller:
-          defaultIssuer:
-            name: private-giantswarm
-```
-
 ### Changed
 
-- Use a YAML object for the apps configuration.
+- Use a YAML object for the apps configuration, so that defaults are not overwritten when users pass custom values.
 
 ## [0.40.0] - 2023-11-27
 

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -83,8 +83,12 @@ metadata:
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
   namespace: {{ $.Release.Namespace }}
 data:
+  {{- if kindIs "string" .configMap.values }}
+  {{- (tpl (.configMap | toYaml | toString) $) | nindent 2 }}
+  {{- else }}
   values: |
   {{- (tpl (.configMap.values | toYaml | toString) $) | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- if .secret }}
 ---

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -83,7 +83,8 @@ metadata:
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
   namespace: {{ $.Release.Namespace }}
 data:
-  {{- (tpl (.configMap | toYaml | toString) $) | nindent 2 }}
+  values: |
+  {{- (tpl (.configMap.values | toYaml | toString) $) | nindent 4 }}
 {{- end }}
 {{- if .secret }}
 ---

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -493,7 +493,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "object"
+                                    "type": ["object", "string"]
                                 }
                             }
                         }
@@ -506,7 +506,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "object"
+                                    "type": ["object", "string"]
                                 }
                             }
                         }
@@ -519,7 +519,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "object"
+                                    "type": ["object", "string"]
                                 }
                             }
                         }
@@ -532,7 +532,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "object"
+                                    "type": ["object", "string"]
                                 }
                             }
                         }

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -493,7 +493,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "string"
+                                    "type": "object"
                                 }
                             }
                         }
@@ -506,7 +506,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "string"
+                                    "type": "object"
                                 }
                             }
                         }
@@ -519,7 +519,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "string"
+                                    "type": "object"
                                 }
                             }
                         }
@@ -532,7 +532,7 @@
                             "type": "object",
                             "properties": {
                                 "values": {
-                                    "type": "string"
+                                    "type": "object"
                                 }
                             }
                         }

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -4,7 +4,7 @@ organization: ""
 userConfig:
   certManager:
     configMap:
-      values: |
+      values:
         # cert-manager-app v2.x.x
         controller:
           extraArgs:
@@ -37,24 +37,24 @@ userConfig:
           enabled: true
   cluster-autoscaler:
     configMap:
-      values: |
+      values:
         serviceAccount:
           annotations:
-            eks.amazonaws.com/role-arn: {{ .Values.clusterName }}-cluster-autoscaler-role
+            eks.amazonaws.com/role-arn: "{{ .Values.clusterName }}-cluster-autoscaler-role"
   externalDns:
     configMap:
-      values: |
+      values:
         provider: aws
         aws:
           irsa: "true"
           batchChangeInterval: null
         serviceAccount:
           annotations:
-            eks.amazonaws.com/role-arn: {{ .Values.clusterName }}-Route53Manager-Role
+            eks.amazonaws.com/role-arn: "{{ .Values.clusterName }}-Route53Manager-Role"
         domainFilters:
-          - {{ .Values.baseDomain }}
+          - "{{ .Values.baseDomain }}"
         txtOwnerId: giantswarm-io-external-dns
-        txtPrefix: {{ .Values.clusterName }}
+        txtPrefix: "{{ .Values.clusterName }}"
         annotationFilter: giantswarm.io/external-dns=managed
         sources:
           - service
@@ -62,12 +62,12 @@ userConfig:
           - "--aws-batch-change-interval=10s"
   netExporter:
     configMap:
-      values: |
+      values:
         NetExporter:
           NTPServers: 169.254.169.123
   etcdKubernetesResourceCountExporter:
     configMap:
-      values: |
+      values:
         etcd:
           hostPath: "/etc/kubernetes/pki/etcd/"
           cacertpath: "/certs/ca.crt"


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/28348

Until now, whenever a user specified values for an app in `default-apps-aws`, these would overwrite all the defaults for that app. That means that if a customer needs to specify one flag, they need to copy all the default configuration we have here in order not to lose any configuration.

The goal of this PR is to allow users of this chart to be able to specify partial values and keep whatever defaults were defined in this repository. 

### Checklist

- [X] Update changelog in CHANGELOG.md.

