### PR TITLE
Allow priority customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow customization of the extraConfig priority.
-=======
 
 ## [0.44.0] - 2024-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow customization of the extraConfig priority.
+
 ## [0.43.0] - 2024-01-25
 
 ### Added

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -56,6 +56,9 @@ spec:
   - kind: {{ $extraConfig.kind }}
     name: {{ tpl $extraConfig.name $ }}
     namespace: {{ tpl $extraConfig.namespace $ }}
+    {{- if $extraConfig.priority }}
+    priotity: {{ $extraConfig.priority }}
+    {{- end}}
   {{- end }}
   {{- end }}
 {{- with (get $.Values.userConfig $key) }}


### PR DESCRIPTION
### What this PR does / why we need it

Allow customers to customize extraconfig priorities.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
