### PR TITLE
Bump version to support  kubernetes 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `aws-pod-identity-webhook` to `v1.14.1`. Now has the correct `policy/v1` for the PodDisruptionBudget.
+- Bump `capi-node-labeler` to `v0.5.0`. Now supports PSS.
+
 ## [0.44.0] - 2024-01-26
 
 ## [0.43.0] - 2024-01-25

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -131,7 +131,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/aws-pod-identity-webhook
-    version: 1.13.2
+    version: 1.14.1
   capi-node-labeler:
     appName: capi-node-labeler
     chartName: capi-node-labeler
@@ -143,7 +143,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/capi-node-labeler-app
-    version: 0.3.4
+    version: 0.5.0
   certExporter:
     appName: cert-exporter
     chartName: cert-exporter


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
