### PR TITLE
Add dependencies on `prometheus-operator-crd` for quicker deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow customization of the extraConfig priority.
+- Add dependencies on `prometheus-operator-crd` for quicker deployment
 
 ## [0.45.1] - 2024-02-01
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add security-bundle app 
+- Add security-bundle app
 
 ## [0.42.0] - 2024-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Update teleport-kube-agent-app to v0.7.1
+- Update external-dns-app to v3.0.0
+- Update vertical-pod-autoscaler-app to v5.0.0
+- Update etcd-kubernetes-resources-count-exporter to v1.9.0
 - Add dependencies on `prometheus-operator-crd` for quicker deployment
 
 ## [0.45.2] - 2024-02-05

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -262,6 +262,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     enabled: true
     inCluster: true
     namespace: kube-system
@@ -275,6 +276,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     enabled: true
     inCluster: true
     namespace: kube-system

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -152,6 +152,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate
@@ -202,6 +203,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate
@@ -226,6 +228,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate
@@ -238,6 +241,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate
@@ -257,13 +261,13 @@ apps:
     # repo: giantswarm/vertical-pod-autoscaler-app
     version: 4.6.0
   observabilityBundle:
+    # Includes prometheus-operator-crd
     appName: observability-bundle
     chartName: observability-bundle
     catalog: default
     clusterValues:
       configMap: true
       secret: false
-    dependsOn: prometheus-operator-crd
     enabled: true
     inCluster: true
     namespace: kube-system


### PR DESCRIPTION
### What this PR does / why we need it

Similar to https://github.com/giantswarm/default-apps-azure/pull/213. This makes CAPZ/CAPA default apps consistent.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites