### PR TITLE
resolve baseDomain diff when cluster-values is not injected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow customization of the extraConfig priority.
 
+### Fixed
+
+- Resolve baseDomain inconcistency when cluster-values is not configured for this App.
+
 ## [0.45.1] - 2024-02-01
 
 ### Fixed

--- a/helm/default-apps-aws/templates/_helpers.tpl
+++ b/helm/default-apps-aws/templates/_helpers.tpl
@@ -47,3 +47,15 @@ config:
     name: {{ .Values.clusterName }}-cluster-values
     namespace: {{ .Release.Namespace }}
 {{- end -}}
+
+{{/*
+Resolve App CR inconcistencies when baseDomain is taken from the catalog or from cluster-values. 
+See https://github.com/giantswarm/giantswarm/issues/29733
+*/}}
+{{- define "baseDomain" -}}
+{{- if hasPrefix .Values.clusterName .Values.baseDomain -}}
+{{- printf "%s" .Values.baseDomain -}}
+{{- else -}}
+{{- printf "%s.%s" .Values.clusterName .Values.baseDomain -}}
+{{- end -}}
+{{- end -}}

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -1,5 +1,6 @@
 clusterName: ""
 organization: ""
+baseDomain: ""
 
 userConfig:
   certManager:

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -52,7 +52,7 @@ userConfig:
           annotations:
             eks.amazonaws.com/role-arn: "{{ .Values.clusterName }}-Route53Manager-Role"
         domainFilters:
-          - "{{ .Values.baseDomain }}"
+          - '{{ include "baseDomain" . }}'
         txtOwnerId: giantswarm-io-external-dns
         txtPrefix: "{{ .Values.clusterName }}"
         annotationFilter: giantswarm.io/external-dns=managed


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

Depending on how the App CR is generated, the cluster-values CM may or
may not be present. This leads to wrong assumptions when using those
values.
This PR takes both cases into account.

Towards https://github.com/giantswarm/giantswarm/issues/29733

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
