### PR TITLE
cert-manager-set-ingresss-shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set `ingresShim` for `cert-manager` app.
+
 ### Fixed
 
 - Default app priority typo.

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -6,34 +6,14 @@ userConfig:
   certManager:
     configMap:
       values:
-        # cert-manager-app v2.x.x
-        controller:
-          extraArgs:
-            # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
-            # their public IPs. Since those are not reachable from private clusters, we instead rely on the
-            # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
-            #
-            # Without this, we get an error like
-            #
-            #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
-            #
-            # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
-            #
-            # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
-            - --dns01-recursive-nameservers-only
-        # cert-manager-app v3.x.x
         # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
         # their public IPs. Since those are not reachable from private clusters, we instead rely on the
         # recursive nameserver (for AWS, that's normally the default nameserver requested in EC2 instances).
-        #
-        # Without this, we get an error like
-        #
-        #   cert-manager/challenges "msg"="propagation check failed" "error"="dial tcp 205.251.194.0:53: i/o timeout"
-        #
-        # where the IP is an AWS nameserver, and DNS-over-TCP is attempted after UDP has failed before.
-        #
-        # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
         dns01RecursiveNameserversOnly: true
+        ingressShim:
+          defaultIssuerName: letsencrypt-giantswarm
+          defaultIssuerKind: ClusterIssuer
+          defaultIssuerGroup: cert-manager.io
         ciliumNetworkPolicy:
           enabled: true
   cluster-autoscaler:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29878

to align with vintage 

/run cluster-test-suites
