### PR TITLE
Add `cilium-servicemonitors` app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cilium-servicemonitors` app.
+
 ## [0.49.0] - 2024-02-20
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -134,14 +134,14 @@ apps:
     version: 1.1.1
   ciliumServiceMonitors:
     appName: cilium-servicemonitors
-    chartName: cilium-servicemonitors-app
+    chartName: cilium-servicemonitors
     catalog: default
     enabled: true
     clusterValues:
       configMap: false
       secret: false
     dependsOn: prometheus-operator-crd
-    namespace: giantswarm
+    namespace: kube-system
     # used by renovate
     # repo: giantswarm/chart-operator-extensions
     version: 0.1.2

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -132,6 +132,19 @@ apps:
     # used by renovate
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
+  ciliumServiceMonitors:
+    appName: cilium-servicemonitors
+    chartName: cilium-servicemonitors-app
+    catalog: default
+    enabled: true
+    clusterValues:
+      configMap: false
+      secret: false
+    dependsOn: prometheus-operator-crd
+    namespace: giantswarm
+    # used by renovate
+    # repo: giantswarm/chart-operator-extensions
+    version: 0.1.2
   cluster-autoscaler:
     appName: cluster-autoscaler
     chartName: cluster-autoscaler-app

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -143,7 +143,7 @@ apps:
     dependsOn: prometheus-operator-crd
     namespace: kube-system
     # used by renovate
-    # repo: giantswarm/chart-operator-extensions
+    # repo: giantswarm/cilium-servicemonitors-app
     version: 0.1.2
   cluster-autoscaler:
     appName: cluster-autoscaler


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3283

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
