### PR TITLE
Set external-dns registry value to `txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `cilium-servicemonitors` app.
 
+### Fixed
+
+- Set externalDns registry value explicitly to avoid conflicts with Catalog value.
+
 ## [0.49.0] - 2024-02-20
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -36,6 +36,7 @@ userConfig:
           - '{{ include "baseDomain" . }}'
         txtOwnerId: giantswarm-io-external-dns
         txtPrefix: "{{ .Values.clusterName }}"
+        registry: txt
         annotationFilter: giantswarm.io/external-dns=managed
         sources:
           - service


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/30009

This is needed because in some cases, the `registry` value is used for other purposes, breaking the schemas.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
