### PR TITLE
Bump `teleport-kube-agent-app` to `v0.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `teleport-kube-agent` to 0.9.0.
+
 ## [0.51.0] - 2024-04-15
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -283,7 +283,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/teleport-kube-agent-app
-    version: 0.8.0
+    version: 0.9.0
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30580

### What this PR does / why we need it

- Bumps `teleport-kube-agent-app` to `v0.9.0` which has toleration and nodeAffinity to prefer scheduling pods in control plane.

<!-- Short summary on what this PR is changing. -->

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### E2E Tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this command in a pull request comment or description

`/run cluster-test-suites`

If for some reason you want to skip the E2E tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
