### PR TITLE
Downgrade vertical-pod-autoscaler to v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Downgrade vertical-pod-autoscaler to v5.1.0 due to a bug in newer version that causes the updater to panic.
+
 ## [0.51.0] - 2024-04-15
 
 ### Added

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -242,7 +242,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-app
-    version: 5.2.1
+    version: 5.1.0
   observabilityBundle:
     # Includes prometheus-operator-crd
     appName: observability-bundle


### PR DESCRIPTION
Downgrade vertical-pod-autoscaler to v5.1.0 due to a bug in newer version that causes the updater to panic.

### What this PR does / why we need it

⚠️  I believe that this latest release of vertical-pod-autoscaler-app is broken https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/281.

It pulls in upstream v1.1.0 which contains [this change](https://github.com/kubernetes/autoscaler/pull/6460) which is I believe not working properly (or we have some issues that got uncovered here).

I have tested this on golem where VPA updater was crashlooping in the clusters that use vertical-pod-autoscaler-app v5.2.1, and the error can be tracked down to previously mentioned upstream VPA change. Test clusters were deployed with [this cluster-aws PR](https://github.com/giantswarm/cluster-aws/pull/581) where default apps are in cluster+cluster-aws and VPA app is on the latest (I think broken) version.

VPA app have been already updated in default-apps-aws here https://github.com/giantswarm/default-apps-aws/pull/455, but luckily not yet released (so not yet used in e2e tests which is why we have not seen the effects of the issue yet). I believe that [this e2e test failure](https://github.com/giantswarm/default-apps-aws/pull/455#issuecomment-2056552265) was a genuine one, but e2e tests had passed eventually there, since VPA updater is crashlooping, but when it gets restarted it is ready and running for some time.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### E2E Tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this command in a pull request comment or description

`/run cluster-test-suites`

If for some reason you want to skip the E2E tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
