### PR TITLE
Add flag to enable moving resources to cluster-aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws` that enables migration of apps from default-apps-aws to cluster-aws (apps are paused, so they are not removed from the WC when default-apps-aws is deleted).
+
+### Fixed
 - Downgrade vertical-pod-autoscaler to v5.1.0 due to a bug in newer version that causes the updater to panic.
 
 ## [0.51.0] - 2024-04-15

--- a/helm/default-apps-aws/ci/ci-values.yaml
+++ b/helm/default-apps-aws/ci/ci-values.yaml
@@ -1,1 +1,3 @@
 clusterName: test
+deleteOptions:
+  moveAppsHelmOwnershipToClusterAws: false

--- a/helm/default-apps-aws/ci/ci-values.yaml
+++ b/helm/default-apps-aws/ci/ci-values.yaml
@@ -1,3 +1,1 @@
 clusterName: test
-deleteOptions:
-  moveAppsHelmOwnershipToClusterAws: false

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -10,6 +10,9 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
+    {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}  
@@ -81,6 +84,10 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
@@ -98,6 +105,10 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -10,7 +10,7 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
-    {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+    {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
     helm.sh/resource-policy: keep
     {{- end }}
   labels:
@@ -84,7 +84,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+  {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
   annotations:
     helm.sh/resource-policy: keep
   {{- end }}
@@ -105,7 +105,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+  {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
   annotations:
     helm.sh/resource-policy: keep
   {{- end }}

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -10,7 +10,10 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
-    {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+    {{- if and $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws (not .inCluster) }}
+    {{- /* We add pause annotation to all apps except bundles (.inCluster==true), because we
+           delete bundles from the MC in order to trigger correct deletion of bundled apps.
+    */}}
     app-operator.giantswarm.io/paused: "true"
     {{- end }}
   labels:

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -84,10 +84,6 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
-  annotations:
-    helm.sh/resource-policy: keep
-  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
@@ -105,10 +101,6 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
-  annotations:
-    helm.sh/resource-policy: keep
-  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values

--- a/helm/default-apps-aws/templates/apps.yaml
+++ b/helm/default-apps-aws/templates/apps.yaml
@@ -11,7 +11,7 @@ metadata:
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
     {{- if $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
-    helm.sh/resource-policy: keep
+    app-operator.giantswarm.io/paused: "true"
     {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -95,9 +95,14 @@ spec:
 
           echo "Remove app-operator finalizer for all Apps owned by default-apps-aws (except bundles that we want to delete regularly)"
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
-            if ! grep -q "bundle" <<< "$app_name"; then
-              kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
-            fi
+            case "$app_name" in
+              *bundle*)
+                echo "do nothing for bundles"
+                ;;
+              *)
+                kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+                ;;
+            esac
           done
 
           echo "Remove app-operator finalizer from all observability-bundle apps"

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -72,9 +72,21 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: update-apps-release-name
         image: gsoci.azurecr.io/giantswarm/kubectl:1.29.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
         command:
         - "/bin/sh"
         - "-xc"

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -95,11 +95,13 @@ spec:
 
           echo "Update Helm release name for all Apps owned by"
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
-            kubectl patch $app_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+            kubectl annotate -n $NAMESPACE $app_name helm.sh/resource-policy-
           done
 
           echo "Update Helm release name for all ConfigMaps"
           for config_map_name in $(kubectl get ConfigMaps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
-            kubectl patch $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+            kubectl annotate -n $NAMESPACE $config_map_name helm.sh/resource-policy-
           done
 {{- end }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -17,6 +17,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -25,7 +25,7 @@ rules:
   resources: ["apps"]
   verbs: ["get", "list", "patch", "update"]
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+      containers:
+      - name: update-apps-release-name
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.2
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+
+          echo "Update Helm release name for all Apps owned by"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
+            kubectl patch $app_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+          done
+
+          echo "Update Helm release name for all ConfigMaps"
+          for config_map_name in $(kubectl get ConfigMaps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
+            kubectl patch $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
+          done
+
+
+          CONFIG_MAP_NAME="myplay"
+          cm=$(kubectl get ConfigMap $CONFIG_MAP_NAME -o json)
+          releaseName=$(echo "$cm" | jq -r ".metadata.annotations[\"meta.helm.sh\/release-name\"]")
+
+          echo "before check"
+          if [ "$releaseName" = "default-play" ]; then
+            echo "found old default play"
+            kubectl patch ConfigMap $CONFIG_MAP_NAME --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "play"}}}'
+            kubectl annotate ConfigMap $CONFIG_MAP_NAME helm.sh/resource-policy-
+            echo "now we have a new play"
+          fi
+          echo "after check, will sleep now"
+          # sleep 60s
+          echo "done sleeping"
+{{- end }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -88,20 +88,4 @@ spec:
           for config_map_name in $(kubectl get ConfigMaps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
             kubectl patch $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
           done
-
-
-          CONFIG_MAP_NAME="myplay"
-          cm=$(kubectl get ConfigMap $CONFIG_MAP_NAME -o json)
-          releaseName=$(echo "$cm" | jq -r ".metadata.annotations[\"meta.helm.sh\/release-name\"]")
-
-          echo "before check"
-          if [ "$releaseName" = "default-play" ]; then
-            echo "found old default play"
-            kubectl patch ConfigMap $CONFIG_MAP_NAME --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "play"}}}'
-            kubectl annotate ConfigMap $CONFIG_MAP_NAME helm.sh/resource-policy-
-            echo "now we have a new play"
-          fi
-          echo "after check, will sleep now"
-          # sleep 60s
-          echo "done sleeping"
 {{- end }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -93,9 +93,11 @@ spec:
         - |
           NAMESPACE="{{ $.Release.Namespace }}"
 
-          echo "Remove app-operator finalizer for all Apps owned by default-apps-aws"
+          echo "Remove app-operator finalizer for all Apps owned by default-apps-aws (except bundles that we want to delete regularly)"
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
-            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+            if ! grep -q "bundle" <<< "$app_name"; then
+              kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+            fi
           done
 
           echo "Remove app-operator finalizer from all observability-bundle apps"

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -97,11 +97,23 @@ spec:
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
             kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
             kubectl annotate -n $NAMESPACE $app_name helm.sh/resource-policy-
+            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/instance-
+            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/name-
+            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/version-
+            kubectl label -n $NAMESPACE $app_name application.giantswarm.io/team-
+            kubectl label -n $NAMESPACE $app_name giantswarm.io/managed-by-
+            kubectl label -n $NAMESPACE $app_name helm.sh/chart-
           done
 
           echo "Update Helm release name for all ConfigMaps"
           for config_map_name in $(kubectl get ConfigMaps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
             kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
             kubectl annotate -n $NAMESPACE $config_map_name helm.sh/resource-policy-
+            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/instance-
+            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/name-
+            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/version-
+            kubectl label -n $NAMESPACE $config_map_name application.giantswarm.io/team-
+            kubectl label -n $NAMESPACE $config_map_name giantswarm.io/managed-by-
+            kubectl label -n $NAMESPACE $config_map_name helm.sh/chart-
           done
 {{- end }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -97,23 +97,23 @@ spec:
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
             kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
             kubectl annotate -n $NAMESPACE $app_name helm.sh/resource-policy-
-            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/instance-
-            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/name-
-            kubectl label -n $NAMESPACE $app_name app.kubernetes.io/version-
-            kubectl label -n $NAMESPACE $app_name application.giantswarm.io/team-
-            kubectl label -n $NAMESPACE $app_name giantswarm.io/managed-by-
-            kubectl label -n $NAMESPACE $app_name helm.sh/chart-
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/instance": "{{ $.Values.clusterName }}"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/name": "cluster"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/version": "0.18.0"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"application.giantswarm.io/team": "turtles"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"giantswarm.io/managed-by": "cluster"}}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"labels": {"helm.sh/chart": "cluster-0.18.0"}}}'
           done
 
           echo "Update Helm release name for all ConfigMaps"
           for config_map_name in $(kubectl get ConfigMaps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
             kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "{{ $.Values.clusterName }}"}}}'
             kubectl annotate -n $NAMESPACE $config_map_name helm.sh/resource-policy-
-            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/instance-
-            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/name-
-            kubectl label -n $NAMESPACE $config_map_name app.kubernetes.io/version-
-            kubectl label -n $NAMESPACE $config_map_name application.giantswarm.io/team-
-            kubectl label -n $NAMESPACE $config_map_name giantswarm.io/managed-by-
-            kubectl label -n $NAMESPACE $config_map_name helm.sh/chart-
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/instance": "{{ $.Values.clusterName }}"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/name": "cluster"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"app.kubernetes.io/version": "0.18.0"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"application.giantswarm.io/team": "turtles"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"giantswarm.io/managed-by": "cluster"}}}'
+            kubectl patch -n $NAMESPACE $config_map_name --type=merge -p '{"metadata": {"labels": {"helm.sh/chart": "cluster-0.18.0"}}}'
           done
 {{- end }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -55,7 +55,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
     "helm.sh/hook-weight": "0"
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
+++ b/helm/default-apps-aws/templates/move-apps-to-cluster-aws.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -18,7 +18,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -37,7 +37,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -57,7 +57,7 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "0"
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/default-apps-aws/templates/propagate-pause-to-bundled-apps.yaml
+++ b/helm/default-apps-aws/templates/propagate-pause-to-bundled-apps.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    "helm.sh/hook": "post-delete"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
@@ -14,10 +14,10 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    "helm.sh/hook": "post-delete"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
@@ -33,30 +33,30 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    "helm.sh/hook": "post-delete"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   namespace: "{{ $.Release.Namespace }}"
 roleRef:
   kind: Role
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+  name: {{ $.Values.clusterName }}-propagate-pause
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    "helm.sh/hook": "post-delete"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     "helm.sh/hook-weight": "0"
   labels:
@@ -65,13 +65,13 @@ spec:
   ttlSecondsAfterFinished: 2592000 # 30 days
   template:
     metadata:
-      name: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+      name: {{ $.Values.clusterName }}-propagate-pause
       namespace: "{{ $.Release.Namespace }}"
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-aws
+      serviceAccountName: {{ $.Values.clusterName }}-propagate-pause
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -93,18 +93,13 @@ spec:
         - |
           NAMESPACE="{{ $.Release.Namespace }}"
 
-          echo "Remove app-operator finalizer for all Apps owned by default-apps-aws"
-          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-aws,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
-            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
-          done
-
-          echo "Remove app-operator finalizer from all observability-bundle apps"
+          echo "Add pause annotation to all observability-bundle apps"
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
-            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
           done
 
-          echo "Remove app-operator finalizer from all security-bundle apps"
+          echo "Add pause annotation to all security-bundle apps"
           for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
-            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
           done
 {{- end }}

--- a/helm/default-apps-aws/values.schema.json
+++ b/helm/default-apps-aws/values.schema.json
@@ -586,6 +586,18 @@
         "clusterName": {
             "type": "string"
         },
+        "deleteOptions": {
+            "type": "object",
+            "title": "Delete options",
+            "properties": {
+                "moveAppsHelmOwnershipToClusterAws": {
+                    "type": "boolean",
+                    "title": "Move Apps Helm ownership to cluster-aws",
+                    "description": "Don't delete Apps (and their ConfigMaps) and update Helm `meta.helm.sh/release-name` annotation on all resources so they are owned by cluster-aws. That way cluster-aws can continue updating same resources that were previously created by default-apps-aws.",
+                    "default": false
+                }
+            }
+        },
         "organization": {
             "type": "string"
         },

--- a/helm/default-apps-aws/values.yaml
+++ b/helm/default-apps-aws/values.yaml
@@ -2,6 +2,9 @@ clusterName: ""
 organization: ""
 baseDomain: ""
 
+deleteOptions:
+  moveAppsHelmOwnershipToClusterAws: false
+
 userConfig:
   certManager:
     configMap:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3119

This PR adds a Helm boolean value that, when enabled, will create post-delete hook where all resources will have their `meta.helm.sh/release-name` annotation updated to cluster name, which means that Helm will see those resources as they are deployed by cluster-aws, and then cluster-aws can continue updating them.

Cluster migration steps are:
- Update cluster to the latest version of default-apps-aws (with this change). Nothing should change as the `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws` is disabled by default.
- Update `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAws` to `true`. Verify that all App resources and ConfigMaps from default-apps-aws have `helm.sh/resource-policy: keep` annotation set.
- Delete `<cluster name>-default-apps` App. Verify that all resources from default-apps-aws have their `meta.helm.sh/release-name` annotation updated to `<cluster name>`.
- Update cluster to the latest version of cluster-aws (new TBA release with this change https://github.com/giantswarm/cluster-aws/pull/581).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### E2E Tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this command in a pull request comment or description

`/run cluster-test-suites`

If for some reason you want to skip the E2E tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
